### PR TITLE
Fix staged firmware programming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ target_sources(
     src/cmd.cpp
     src/disc_image.cpp
     src/drive_mechanics.cpp
+    src/firmware_update.cpp
     src/i2s.cpp
     src/main.cpp
     src/modchip.cpp
@@ -135,9 +136,12 @@ pico_generate_pio_header(${PROJECT_NAME} ${CMAKE_CURRENT_LIST_DIR}/pio/main.pio)
 target_link_libraries(
     ${PROJECT_NAME} PRIVATE
     hardware_dma
+    hardware_flash
     hardware_pio
     hardware_pwm
+    hardware_sync
     hardware_vreg
+    hardware_watchdog
     hardware_i2c
     SD-fatfs
     pico_bootrom

--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@ I've taken some pretty drastic design choices with my fork of this project, such
 
 ### Notes
 - Please make sure your SD card is formatted as exFAT.
+- Firmware updates can be installed by copying a new `PICOSTATION.UF2` file to the root of the SD card. The Pico will stage and
+  apply the update automatically on the next boot before launching the menu. Make sure the UF2 file is 1MB or smaller so it fits
+  in the reserved update space.
 
 
 ### To-do
 - ~~Stabilize image loading~~
 - Make an interface for image choice/loading
-- ~~Make it possible to update the pico via SD card~~ <- Maybe this eventually, but not really a priority for me at the moment.
+- ~~Make it possible to update the pico via SD card~~ (drop `PICOSTATION.UF2` in the SD root and power on to auto-update).
 
 ### Links
 - Original repo this fork is based on: https://github.com/paulocode/picostation

--- a/include/firmware_update.h
+++ b/include/firmware_update.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace picostation {
+
+// Checks for staged firmware updates stored in flash and applies them if present.
+// If an update package named PICOSTATION.UF2 exists on the SD card it will be
+// staged and applied automatically. The function reboots the Pico when an
+// update is successfully installed.
+void checkForFirmwareUpdate();
+
+}  // namespace picostation

--- a/src/firmware_update.cpp
+++ b/src/firmware_update.cpp
@@ -1,0 +1,318 @@
+#include "firmware_update.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "ff.h"
+#include "hardware/flash.h"
+#include "hardware/sync.h"
+#include "hardware/watchdog.h"
+#include "pico/bootrom.h"
+#include "hardware/regs/addressmap.h"
+#include "hardware/regs/m0plus.h"
+
+namespace {
+
+constexpr char kUpdateFileName[] = "PICOSTATION.UF2";
+constexpr uint32_t kUpdateMagic = 0x5049434f;  // "PICO"
+constexpr uint32_t kUf2MagicStart0 = 0x0a324655;
+constexpr uint32_t kUf2MagicStart1 = 0x9e5d5157;
+constexpr uint32_t kUf2MagicEnd = 0x0ab16f30;
+constexpr uint32_t kUf2BlockSize = 512;
+constexpr uint32_t kUpdateRegionSize = 1024 * 1024;  // 1MB reserved for staged updates
+constexpr uint32_t kHeaderSize = FLASH_PAGE_SIZE;
+constexpr uint32_t kUpdateRegionOffset = PICO_FLASH_SIZE_BYTES - kUpdateRegionSize;
+constexpr uint32_t kUf2FlagNotMainFlash = 0x00000001;
+constexpr uint32_t kUf2FlagFamilyIdPresent = 0x00002000;
+constexpr uint32_t kRp2040FamilyId = 0xe48bff56;
+
+static_assert(kUpdateRegionSize < PICO_FLASH_SIZE_BYTES, "Update storage must leave application flash available");
+
+struct UpdateHeader {
+    uint32_t magic;
+    uint32_t file_size;
+    uint32_t stored_size;
+    uint32_t reserved;
+};
+
+struct Uf2Block {
+    uint32_t magic_start0;
+    uint32_t magic_start1;
+    uint32_t flags;
+    uint32_t target_address;
+    uint32_t payload_size;
+    uint32_t block_number;
+    uint32_t block_count;
+    uint32_t family_id;
+    uint8_t data[476];
+    uint32_t magic_end;
+};
+
+static_assert(sizeof(Uf2Block) == kUf2BlockSize, "UF2 block layout mismatch");
+static_assert(kUpdateRegionOffset % FLASH_SECTOR_SIZE == 0, "Update storage must be sector aligned");
+
+extern "C" const uint8_t __flash_binary_end;
+
+FATFS g_updateFatFs;
+
+const UpdateHeader *getHeader() {
+    return reinterpret_cast<const UpdateHeader *>(XIP_BASE + kUpdateRegionOffset);
+}
+
+uint32_t align_up(uint32_t value, uint32_t alignment) {
+    return (value + alignment - 1u) & ~(alignment - 1u);
+}
+
+bool stageUpdateFile(FIL &file, uint32_t file_size);
+bool applyStagedUpdateIfPresent();
+bool stageUpdateFromSD();
+bool __not_in_flash_func(processStagedUpdate)(const UpdateHeader *header, bool program);
+[[noreturn]] void __not_in_flash_func(applyUpdateAndReboot)(const UpdateHeader *header);
+void invalidateHeader();
+bool hasUpdateRegionSpace();
+
+}  // namespace
+
+void picostation::checkForFirmwareUpdate() {
+    // Apply a staged update from a previous boot if present.
+    if (applyStagedUpdateIfPresent()) {
+        return;
+    }
+
+    FRESULT fr = f_mount(&g_updateFatFs, "", 1);
+    if (fr != FR_OK) {
+        return;
+    }
+
+    stageUpdateFromSD();
+
+    f_unmount("");
+}
+
+namespace {
+
+bool applyStagedUpdateIfPresent() {
+    if (!hasUpdateRegionSpace()) {
+        return false;
+    }
+
+    const UpdateHeader *header = getHeader();
+    if (header->magic != kUpdateMagic) {
+        return false;
+    }
+
+    if (header->file_size == 0 || header->file_size > (kUpdateRegionSize - kHeaderSize)) {
+        invalidateHeader();
+        return false;
+    }
+
+    if ((header->file_size % kUf2BlockSize) != 0) {
+        invalidateHeader();
+        return false;
+    }
+
+    // Validate the staged image before attempting to apply it.
+    if (!processStagedUpdate(header, false)) {
+        invalidateHeader();
+        return false;
+    }
+
+    applyUpdateAndReboot(header);
+    __builtin_unreachable();
+}
+
+bool stageUpdateFromSD() {
+    if (!hasUpdateRegionSpace()) {
+        return false;
+    }
+
+    FILINFO file_info;
+    FRESULT fr = f_stat(kUpdateFileName, &file_info);
+    if (fr != FR_OK) {
+        return false;
+    }
+
+    if (file_info.fsize == 0 || (file_info.fsize % kUf2BlockSize) != 0) {
+        return false;
+    }
+
+    if (file_info.fsize > (kUpdateRegionSize - kHeaderSize)) {
+        return false;
+    }
+
+    FIL file;
+    fr = f_open(&file, kUpdateFileName, FA_READ);
+    if (fr != FR_OK) {
+        return false;
+    }
+
+    bool staged = stageUpdateFile(file, static_cast<uint32_t>(file_info.fsize));
+
+    f_close(&file);
+
+    if (!staged) {
+        return false;
+    }
+
+    f_unlink(kUpdateFileName);
+
+    // Applying will reboot the system on success.
+    applyStagedUpdateIfPresent();
+    return true;
+}
+
+bool stageUpdateFile(FIL &file, uint32_t file_size) {
+    const uint32_t padded_size = align_up(file_size, FLASH_PAGE_SIZE);
+    const uint32_t total_size = align_up(kHeaderSize + padded_size, FLASH_SECTOR_SIZE);
+    if (total_size > kUpdateRegionSize) {
+        return false;
+    }
+
+    flash_range_erase(kUpdateRegionOffset, total_size);
+
+    uint8_t page_buffer[FLASH_PAGE_SIZE];
+    uint32_t written = 0;
+    uint32_t dest_offset = kUpdateRegionOffset + kHeaderSize;
+
+    while (written < file_size) {
+        const uint32_t chunk = (file_size - written) < FLASH_PAGE_SIZE ? (file_size - written) : FLASH_PAGE_SIZE;
+        UINT bytes_read = 0;
+        FRESULT fr = f_read(&file, page_buffer, chunk, &bytes_read);
+        if (fr != FR_OK || bytes_read != chunk) {
+            return false;
+        }
+
+        if (chunk < FLASH_PAGE_SIZE) {
+            for (uint32_t i = chunk; i < FLASH_PAGE_SIZE; ++i) {
+                page_buffer[i] = 0xFF;
+            }
+        }
+
+        flash_range_program(dest_offset, page_buffer, FLASH_PAGE_SIZE);
+        dest_offset += FLASH_PAGE_SIZE;
+        written += chunk;
+    }
+
+    UpdateHeader header = {kUpdateMagic, file_size, padded_size, 0};
+    uint8_t header_buffer[FLASH_PAGE_SIZE];
+    for (uint32_t i = 0; i < FLASH_PAGE_SIZE; ++i) {
+        header_buffer[i] = 0xFF;
+    }
+
+    const uint8_t *header_bytes = reinterpret_cast<const uint8_t *>(&header);
+    for (size_t i = 0; i < sizeof(header); ++i) {
+        header_buffer[i] = header_bytes[i];
+    }
+
+    flash_range_program(kUpdateRegionOffset, header_buffer, FLASH_PAGE_SIZE);
+    return true;
+}
+
+void invalidateHeader() {
+    flash_range_erase(kUpdateRegionOffset, FLASH_SECTOR_SIZE);
+}
+
+bool hasUpdateRegionSpace() {
+    const uint32_t used_flash = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&__flash_binary_end) - XIP_BASE);
+    return used_flash <= kUpdateRegionOffset;
+}
+
+bool __not_in_flash_func(processStagedUpdate)(const UpdateHeader *header, bool program) {
+    const uint8_t *cursor = reinterpret_cast<const uint8_t *>(XIP_BASE + kUpdateRegionOffset + kHeaderSize);
+    const uint8_t *end = cursor + header->file_size;
+
+    static bool erased[kUpdateRegionOffset / FLASH_SECTOR_SIZE];
+    static uint8_t program_buffer[FLASH_PAGE_SIZE * 2];
+    static_assert(sizeof(program_buffer) >= sizeof(Uf2Block::data), "Program buffer too small for UF2 payload");
+
+    if (program) {
+        for (uint32_t i = 0; i < (kUpdateRegionOffset / FLASH_SECTOR_SIZE); ++i) {
+            erased[i] = false;
+        }
+    }
+
+    while (cursor < end) {
+        const Uf2Block *block = reinterpret_cast<const Uf2Block *>(cursor);
+        cursor += kUf2BlockSize;
+        if (block->magic_start0 != kUf2MagicStart0 || block->magic_start1 != kUf2MagicStart1 || block->magic_end != kUf2MagicEnd) {
+            return false;
+        }
+
+        if (block->payload_size == 0 || block->payload_size > sizeof(block->data)) {
+            return false;
+        }
+
+        if ((block->payload_size % FLASH_PAGE_SIZE) != 0) {
+            return false;
+        }
+
+        if (block->target_address < XIP_BASE) {
+            return false;
+        }
+
+        const uint32_t target_offset = block->target_address - XIP_BASE;
+        if (target_offset + block->payload_size > kUpdateRegionOffset) {
+            return false;
+        }
+
+        if ((block->target_address & (FLASH_PAGE_SIZE - 1u)) != 0) {
+            return false;
+        }
+
+        if ((block->flags & kUf2FlagFamilyIdPresent) != 0 && block->family_id != kRp2040FamilyId) {
+            return false;
+        }
+
+        if ((block->flags & kUf2FlagNotMainFlash) != 0) {
+            continue;
+        }
+
+        if (program) {
+            const uint32_t first_sector = target_offset / FLASH_SECTOR_SIZE;
+            const uint32_t last_sector = (target_offset + block->payload_size - 1u) / FLASH_SECTOR_SIZE;
+
+            for (uint32_t sector = first_sector; sector <= last_sector; ++sector) {
+                if (!erased[sector]) {
+                    flash_range_erase(sector * FLASH_SECTOR_SIZE, FLASH_SECTOR_SIZE);
+                    erased[sector] = true;
+                }
+            }
+
+            if (block->payload_size > sizeof(program_buffer)) {
+                return false;
+            }
+
+            for (uint32_t i = 0; i < block->payload_size; ++i) {
+                program_buffer[i] = block->data[i];
+            }
+
+            flash_range_program(target_offset, program_buffer, block->payload_size);
+        }
+
+    }
+
+    return true;
+}
+
+[[noreturn]] void __not_in_flash_func(applyUpdateAndReboot)(const UpdateHeader *header) {
+    uint32_t irq_state = save_and_disable_interrupts();
+
+    const bool programmed = processStagedUpdate(header, true);
+
+    if (programmed) {
+        // Clear the header so the update is not re-applied on the next boot.
+        flash_range_erase(kUpdateRegionOffset, FLASH_SECTOR_SIZE);
+    }
+
+    restore_interrupts(irq_state);
+
+    if (programmed) {
+        watchdog_reboot(0, 0, 0);
+    }
+
+    while (true) {
+        __wfi();
+    }
+}
+
+}  // namespace

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "pico/stdlib.h"
 #include "picostation.h"
 #include "pseudo_atomics.h"
+#include "firmware_update.h"
 #include <cstdio>
 #include <csignal>
 
@@ -18,6 +19,7 @@ int main() {
     initPseudoAtomics();
 
     picostation::initHW();
+    picostation::checkForFirmwareUpdate();
     multicore_launch_core1(picostation::core1Entry);  // I2S Thread
 
     picostation::core0Entry();  // Reset, playback speed, Sled, soct, subq

--- a/third_party/SD-fatfs/fatfs/source/ff.c
+++ b/third_party/SD-fatfs/fatfs/source/ff.c
@@ -4086,15 +4086,15 @@ FRESULT __time_critical_func(f_read_scramble) (
 				if (disk_read((BYTE *) rbuff, sect, cc, sc, dt) != RES_OK) ABORT(fs, FR_DISK_ERR);
 #if !FF_FS_READONLY && FF_FS_MINIMIZE <= 2		/* Replace one of the read sectors with cached data if it contains a dirty sector */
 #if FF_FS_TINY
-				if (fs->wflag && fs->winsect - sect < cc) {
-					uint32_t dst_off = (fs->winsect - sect) * SS(fs);
-					scramble_data((uint32_t *)(rbuff + (dst_off << 1), fs->win, dt ? sc + (dst_off >> 1) : NULL, SS(fs) >> 1);
-				}
+                                if (fs->wflag && fs->winsect - sect < cc) {
+                                        uint32_t dst_off = (fs->winsect - sect) * SS(fs);
+                                        scramble_data((uint32_t *)(rbuff + (dst_off << 1)), fs->win, dt ? sc + (dst_off >> 1) : NULL, SS(fs) >> 1);
+                                }
 #else
-				if ((fp->flag & FA_DIRTY) && fp->sect - sect < cc) {
-					uint32_t dst_off = (fs->sect - sect) * SS(fs);
-					scramble_data((uint32_t *)(rbuff + (dst_off << 1), fs->buf, dt ? sc + (dst_off >> 1) : NULL, SS(fs) >> 1);
-				}
+                                if ((fp->flag & FA_DIRTY) && fp->sect - sect < cc) {
+                                        uint32_t dst_off = (fs->sect - sect) * SS(fs);
+                                        scramble_data((uint32_t *)(rbuff + (dst_off << 1)), fs->buf, dt ? sc + (dst_off >> 1) : NULL, SS(fs) >> 1);
+                                }
 #endif
 #endif
 				rcnt = SS(fs) * cc;				/* Number of bytes transferred */

--- a/third_party/SD-fatfs/fatfs/source/ffconf.h
+++ b/third_party/SD-fatfs/fatfs/source/ffconf.h
@@ -8,7 +8,7 @@
 / Function Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_FS_READONLY	1
+#define FF_FS_READONLY	0
 /* This option switches read-only configuration. (0:Read/Write or 1:Read-only)
 /  Read-only configuration removes writing API functions, f_write(), f_sync(),
 /  f_unlink(), f_mkdir(), f_chmod(), f_rename(), f_truncate(), f_getfree()


### PR DESCRIPTION
## Summary
- switch the staged updater to the SDK flash helpers so erase/program calls compile against the new ROM API
- copy UF2 payloads into SRAM before programming and reset the reboot path to restore interrupts cleanly

## Testing
- cmake -S . -B build *(fails: Raspberry Pi Pico SDK not present in third_party/pico-sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68d755c9eef0832f935652dacf98240c